### PR TITLE
HW08: Terraform 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 */variables.json
-
+# Terraform
+*.tfstate
+*.tfstate.*.backup
+*.tfstate.backup
+*.tfvars
+.terraform/

--- a/terraform/files/deploy.sh
+++ b/terraform/files/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+APP_DIR=${1:-$HOME}
+
+git clone -b monolith https://github.com/express42/reddit.git $APP_DIR/reddit
+cd $APP_DIR/reddit
+bundle install
+
+sudo mv /tmp/puma.service /etc/systemd/system/puma.service
+sudo systemctl start puma
+sudo systemctl enable puma

--- a/terraform/files/puma.service
+++ b/terraform/files/puma.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Puma HTTP Server
+After=network.target
+
+[Service]
+Type=simple
+User=appuser
+WorkingDirectory=/home/appuser/reddit
+ExecStart=/bin/bash -lc 'puma'
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,0 +1,32 @@
+resource "google_compute_target_pool" "reddit" {
+  name = "reddit-target-pool"
+
+  # instances = [
+  #   "europe-west1-b/reddit-app-0",
+  #   "europe-west1-b/reddit-app-1",
+  # ]
+  instances = [
+    "${google_compute_instance.app.*.self_link}"
+  ]
+
+  health_checks = [
+    "${google_compute_http_health_check.http.name}",
+  ]
+}
+
+resource "google_compute_forwarding_rule" "http" {
+  name       = "reddit-forwarding-rule"
+  region     = "europe-west1"
+  target     = "${google_compute_target_pool.reddit.self_link}"
+  port_range = "9292"
+}
+
+
+
+resource "google_compute_http_health_check" "http" {
+  name               = "reddit-http-check"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+  port               = "9292"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,93 @@
+terraform {
+  # Версия terraform
+  required_version = "0.11.11"
+}
+
+provider "google" {
+  # Версия провайдера
+  version = "2.0.0"
+
+  # ID проекта
+  project = "${var.project}"
+  region  = "${var.region}"
+
+  # project = "infra-242917"
+  # region = "europe-west-1"
+}
+
+resource "google_compute_project_metadata" "default" {
+  metadata {
+    ssh-keys = "appuser1:${file(var.public_key_path)} appuser2:${file(var.public_key_path)} appuser3:${file(var.public_key_path)} appuser4:${file(var.public_key_path)} appuser5:${file(var.public_key_path)}"
+  }
+}
+
+resource "google_compute_instance" "app" {
+  count        = "${var.count}"
+  name         = "reddit-app${count.index}"
+  machine_type = "g1-small"
+
+  # zone = "europe-west1-b"
+  zone = "${var.zone}"
+  tags = ["reddit-app"]
+
+  metadata {
+    # путь до публичного ключа
+    ssh-keys = "appuser:${file(var.public_key_path)}"
+  }
+
+  # определение загрузочного диска
+  boot_disk {
+    initialize_params {
+      # image = "reddit-base"
+      image = "${var.disk_image}"
+    }
+  }
+
+  # определение сетевого интерфейса
+  network_interface {
+    # сеть, к которой присоединить данный интерфейс
+    network = "default"
+
+    # использовать ephemeral IP для доступа из Интернет
+    access_config {}
+  }
+
+  connection {
+    type  = "ssh"
+    user  = "appuser"
+    agent = false
+
+    # путь до приватного ключа
+    private_key = "${file(var.private_key_path)}"
+
+    # private_key = "${file(var.public_key_path)}"
+  }
+
+  provisioner "file" {
+    source      = "files/puma.service"
+    destination = "/tmp/puma.service"
+  }
+
+  provisioner "remote-exec" {
+    script = "files/deploy.sh"
+  }
+}
+
+resource "google_compute_firewall" "firewall_puma" {
+  name = "allow-puma-default"
+
+  # Название сети, в которой действует правило
+  network = "default"
+
+  # Какой доступ разрешить
+  allow {
+    protocol = "tcp"
+    ports    = ["9292"]
+  }
+
+  # Каким адресам разрешаем доступ
+  source_ranges = ["0.0.0.0/0"]
+
+  # Правило применимо для инстансов с перечисленными тэгами
+  target_tags = ["reddit-app"]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,8 +1,3 @@
-terraform {
-  # Версия terraform
-  required_version = "0.11.11"
-}
-
 provider "google" {
   # Версия провайдера
   version = "2.0.0"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "app_external_ip" {
+  value = "${google_compute_instance.app.*.network_interface.0.access_config.0.nat_ip}"
+}
+
+output "lb_ip_address" {
+  value = "${google_compute_forwarding_rule.http.ip_address}"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,5 @@
+project = "your_project_id"
+public_key_path = "~/.ssh/appuser.pub"
+private_key_path = "~/.ssh/appuser"
+disk_image = "reddit-base"
+count = 2

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,33 @@
+variable project {
+  description = "Project ID"
+}
+
+variable region {
+  description = "Region"
+
+  # Значение по умолчанию
+  default = "europe-west1"
+}
+
+variable public_key_path {
+  # Описание переменной
+  description = "Path to the public key used for ssh access"
+}
+
+variable disk_image {
+  description = "Disk image"
+}
+
+variable "private_key_path" {
+  description = "Path to the private key used for ssh access"
+}
+
+variable "zone" {
+  description = "Zone"
+  default     = "europe-west1-b"
+}
+
+variable "count" {
+  default = 1
+  description = "How many instances of application should be created"
+}


### PR DESCRIPTION
# Выполнено ДЗ № 08

 - [x] Основное ДЗ
 - [x] Задание со *
 - [x] Задание с **

## В процессе сделано:
- Удален SSH-ключ пользователя appuser из Compute Engine - Metadata - SSH keys
- Установлен Terraform v0.11.11
- Создан конфигурационный файл **terraform/main.tf**
- Добавлены terraform-related исключения в .gitignore
- В **main.tf** добавлено описание провайдера GCP
- Выполнена инициализация модулей Terraform `cd terraform && terraform init`
- В **main.tf** добавлен ресурс **google_compute_instance** для создания vm в GCP
- Проведена валидация планируемых изменений `terraform plan`
- Применены запланированные изменения `terraform apply`
- Получен IP-адрес инстанса из tfstate-файла `terraform show | grep nat_ip`
- Произведена попытка подключения к инстансу по SSH `ssh appuser@34.77.176.212`, подключение не удалось
- В **main.tf** в описание ресурса добавлен раздел metadata, содержащий путь к публичному ключу

<details>
  <summary>ssh metadata</summary>

```bash
metadata {
  # путь до публичного ключа
  ssh-keys = "appuser:${file("~/.ssh/appuser.pub")}"
}
```

</details>

- Изменения проверены и применены к инстансу `terraform plan && terraform apply -auto-approve`
- Проверено подключение к инстансу по SSH, подключение прошло успешно
- Добавлен файл выходных переменных **outputs.tf**
- Добавлена выходная переменна app_external_ip `google_compute_instance.app.network_interface.0.access_config.0.nat_ip`
- Получено значение переменной после выполнения `terraform refresh` и `terraform output`
- Добавлено описание ресурса google_compute_firewall, создающее правило, которое разрешает доступ на 9292 порт
- Изменения применены, создано правило для firewall в GCP
- Добавлен тэг `tags = ["reddit-app"]` для инстанса **google_compute_instance.app**

### Provisioners

- Для ресурса **google_compute_instance.app** добавлен provisioner типа file, который будет копировать файл с локальной машины на создаваемый инстанс

<details>
  <summary>file provisioner</summary>

```ruby
provisioner "file" {
    source = "files/puma.service"
    destination = "/tmp/puma.service"
}
```

</details>

- Для ресурса **google_compute_instance.app** добавлен provisioner типа remote_exec, который будет запускать bash-скрипт на создаваемом инстансе

<details>
  <summary>remote_exec provisioner</summary>

```ruby
provisioner "remote-exec" {
    script = "files/deploy.sh"
}
```

</details>

- Внутрь описания ресурса **google_compute_instance.app** добавлен раздел connection, который определеяет параметры подключения к инстансу для запуска провижионеров

<details>
  <summary>provisioner connection</summary>

```ruby
connection {
  type = "ssh"
  user = "appuser"
  agent = false
  # путь до приватного ключа
  private_key = "${file("~/.ssh/appuser")}"
}
```

</details>

- Т.к. провижионеры запускаются только при создании нового ресурса (или при удалении), то, для выполнения секций провижионинга, ресурс **google_compute_instance.app** помечен для перес оздания при слудеющем применении изменений `terraform taint google_compute_instance.app`
- После применения изменений можно убедитсья, что приложение reddit доступно по <http://your-vm-ip:9292>

### Input Vars

- Добавлен файл под input vars - **variables.tf**
- В файл переменных terraform добавлены переменные: project, region, public_key_path, disk_image
- В файле **main.tf** значения параметров project, region, public_key_path. disk_image изменены на переменные
- Значения переменных, которые не имеют дефолтного значения, определены в файле **terraform.tfvars**
- Инфраструктура пересоздана посредством выполнения команд `terraform destroy -auto-approve && terraform plan && terraform apply -auto-approve`
- После пересоздания приложения доступно по  <http://your-vm-ip:9292>

### Самостоятельное задание

- Определена переменная private_key_path которая используется для подключения провижионеров в ресурсе **google_compute_instance.app**
- Определена переменная zone, которая имеет дефолтное значение и используется в ресурсе **google_compute_instance.app**
- Все файл отформатированы `terraform fmt .`
- Добавлен шаблон переменных **terraform.tfvars.example**

### Задание со звездочкой (*)

- Добавление ключа пользователя в Compute Engine - Metadata

<details>
  <summary>add ssh key for 1 user</summary>

```ruby
resource "google_compute_project_metadata" "default" {
  metadata {
    ssh-keys = "abramov1:${file(var.public_key_path)}"
  }
}
```

</details>

- Добавление ключей нескольких пользователей в Compute Engine - Metadata

<details>
  <summary>Add ssh key for 5 users</summary>

```bash
resource "google_compute_project_metadata" "default" {
  metadata {
    ssh-keys = "appuser1:${file(var.public_key_path)} appuser2:${file(var.public_key_path)} appuser3:${file(var.public_key_path)} appuser4:${file(var.public_key_path)} appuser5:${file(var.public_key_path)}"
  }
}
```

</details>

- В метаданные проекта добавлен ssh-ключ для пользователя appuser_web
- После применения `terraform apply` была обнаружена проблема: ключ пользователя appuser_web был удален из метаданных проекта, остались только те ключи, которые описаны в terraform

### Задание с двумя звездочками (**)

- Добавлен файл **lb.tf** описывающий создание балансировщика для http
- В outputs добавлен вывод ip адреса балансировщика
- Добавлено создание еще одного инстанса, неудобство - копирование кода ведет к разрастанию файла и возможным ошибкам и неодинаковости инстансов
- Добавлено создание второго инстанса с приложением через count
- Добавлено автоматическое добавление инстансов в target_pool
- Добавлен вывод в outputs ip-адресов созданных инстансов

## Как запустить проект:
- Переименовать terraform.tfvars.example в terraform.tfvars и указать в нем имя своего проекта
- Перейти в директорию terraform и выполнить `terraform init && terraform plan && terraform apply -auto-approve`

## Как проверить работоспособность:
 - Посмотреть ip_address балансировщика и перейти по ссылке http://адрес-балансировщика:9292

## PR checklist
 - [x] Выставил label с номером домашнего задания
 - [x] Выставил label с темой домашнего задания