### PR TITLE
Ansible 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@
 .terraform/
 *.retry
 jdauphant.nginx
+# Vagrant & molecule
+.vagrant/
+*.log
+*.pyc
+.molecule
+.cache
+.pytest_cache
+venv
+.bak

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: required
 language: bash
 before_install:
-- if [ $TRAVIS_PULL_REQUEST != "false"] || [ $TRAVIS_BRANCH == 'master' ]; then ./play-travis/hw12.sh; fi
+# - if [ $TRAVIS_PULL_REQUEST != "false"] || [ $TRAVIS_BRANCH == 'master' ]; then ./play-travis/hw12.sh; fi
 - curl https://raw.githubusercontent.com/express42/otus-homeworks/2019-02/run.sh |
   bash
 notifications:

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -1,0 +1,46 @@
+Vagrant.configure("2") do |config|
+
+    config.vm.provider :virtualbox do |v|
+      v.memory = 512
+            # fix macOS sound issue
+            v.customize ["modifyvm", :id, "--audio", "none"]
+    end
+
+    config.vm.define "dbserver" do |db|
+        db.vm.box = "ubuntu/xenial64"
+        db.vm.hostname = "dbserver"
+        db.vm.network :private_network, ip: "10.10.10.10"
+
+        db.vm.provision "ansible" do |ansible|
+          ansible.playbook = "playbooks/site.yml"
+          ansible.groups = {
+          "db" => ["dbserver"],
+          "db:vars" => {"mongo_bind_ip" => "0.0.0.0"}
+          }
+        end
+      end
+
+      config.vm.define "appserver" do |app|
+        app.vm.box = "ubuntu/xenial64"
+        app.vm.hostname = "appserver"
+        app.vm.network :private_network, ip: "10.10.10.20"
+
+        app.vm.provision "ansible" do |ansible|
+          ansible.playbook = "playbooks/site.yml"
+          ansible.groups = {
+          "app" => ["appserver"],
+          "app:vars" => { "db_host" => "10.10.10.10"}
+          }
+
+          ansible.extra_vars = {"deploy_user" => "vagrant",
+          "nginx_sites" => {
+            "default" => [
+              "listen 80 default_server",
+              "server_name reddit",
+              "location / { proxy_pass http://127.0.0.1:9292; }"
+            ]
+          }
+        }
+        end
+      end
+    end

--- a/ansible/playbooks/base.yml
+++ b/ansible/playbooks/base.yml
@@ -1,0 +1,10 @@
+---
+- name: Check && install python
+  hosts: all
+  become: true
+  gather_facts: False
+
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      changed_when: False

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -1,17 +1,20 @@
 - name: Deploy App
   hosts: app
-  tasks:
-  - name: Fetch the latest version of application code
-    git:
-      repo: 'https://github.com/express42/reddit.git'
-      dest: /home/appuser/reddit
-      version: monolith
-    notify: restart puma
+  vars:
+    deploy_user: appuser
 
-  - name: bundle install
-    bundler:
-      state: present
-      chdir: /home/appuser/reddit
+  tasks:
+    - name: Fetch the latest version of application code
+      git:
+        repo: 'https://github.com/express42/reddit.git'
+        dest: "/home/{{ deploy_user }}/reddit"
+        version: monolith
+      notify: restart puma
+
+    - name: bundle install
+      bundler:
+        state: present
+        chdir: "/home/{{ deploy_user }}/reddit"
 
   handlers:
   - name: restart puma

--- a/ansible/playbooks/packer_app.yml
+++ b/ansible/playbooks/packer_app.yml
@@ -2,11 +2,17 @@
 - name: Install Ruby && Bundler
   hosts: all
   become: true
-  tasks:
-  # Установим в цикле все зависимости
-  - name: Install ruby and rubygems and required packages
-    apt: "name={{ item }} state=present"
-    with_items:
-      - ruby-full
-      - ruby-bundler
-      - build-essential
+  roles:
+    - app
+
+# - name: Install Ruby && Bundler
+#   hosts: all
+#   become: true
+#   tasks:
+#   # Установим в цикле все зависимости
+#   - name: Install ruby and rubygems and required packages
+#     apt: "name={{ item }} state=present"
+#     with_items:
+#       - ruby-full
+#       - ruby-bundler
+#       - build-essential

--- a/ansible/playbooks/packer_db.yml
+++ b/ansible/playbooks/packer_db.yml
@@ -2,27 +2,33 @@
 - name: Install MongoDB 3.2
   hosts: all
   become: true
-  tasks:
-  # Добавим ключ репозитория для последующей работы с ним
-  - name: Add APT key
-    apt_key:
-      id: EA312927
-      keyserver: keyserver.ubuntu.com
+  roles:
+    - db
 
-  # Подключаем репозиторий с пакетами mongodb
-  - name: Add APT repository
-    apt_repository:
-      repo: deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse
-      state: present
+# - name: Install MongoDB 3.2
+#   hosts: all
+#   become: true
+#   tasks:
+#   # Добавим ключ репозитория для последующей работы с ним
+#   - name: Add APT key
+#     apt_key:
+#       id: EA312927
+#       keyserver: keyserver.ubuntu.com
 
-  # Выполним установку пакета
-  - name: Install mongodb package
-    apt:
-      name: mongodb-org
-      state: present
+#   # Подключаем репозиторий с пакетами mongodb
+#   - name: Add APT repository
+#     apt_repository:
+#       repo: deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse
+#       state: present
 
-  # Включаем сервис
-  - name: Configure service supervisor
-    systemd:
-      name: mongod
-      enabled: yes
+#   # Выполним установку пакета
+#   - name: Install mongodb package
+#     apt:
+#       name: mongodb-org
+#       state: present
+
+#   # Включаем сервис
+#   - name: Configure service supervisor
+#     systemd:
+#       name: mongod
+#       enabled: yes

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,5 +1,5 @@
 ---
+- import_playbook: base.yml
 - import_playbook: db.yml
 - import_playbook: app.yml
 - import_playbook: deploy.yml
-- import_playbook: users.yml

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,1 +1,4 @@
 ansible>=2.4
+molecule>=2.6
+testinfra>=1.10
+python-vagrant>=0.5.15

--- a/ansible/roles/app/defaults/main.yml
+++ b/ansible/roles/app/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for app
 db_host: 127.0.0.1
 env: local
+deploy_user: appuser

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -1,21 +1,9 @@
 ---
 # tasks file for app
+
 - name: Show info about the env this host belongs to
   debug:
-    msg: "This host is in {{ env }} environment"
+    msg: "This host is in {{ env }} environment!!!"
 
-- name: Add unit file for Puma
-  copy:
-    src: puma.service
-    dest: /etc/systemd/system/puma.service
-  notify: reload puma
-
-- name: Add config for DB connection
-  template:
-    src: db_config.j2
-    dest: /home/appuser/db_config
-    owner: appuser
-    group: appuser
-
-- name: enable puma
-  systemd: name=puma enabled=yes
+- include: ruby.yml
+- include: puma.yml

--- a/ansible/roles/app/tasks/puma.yml
+++ b/ansible/roles/app/tasks/puma.yml
@@ -1,0 +1,16 @@
+---
+- name: Add unit file for Puma
+  template:
+    src: puma.service.j2
+    dest: /etc/systemd/system/puma.service
+  # notify: reload puma
+
+- name: Add config for DB connection
+  template:
+    src: db_config.j2
+    dest: "/home/{{ deploy_user }}/db_config"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+
+- name: enable puma
+  systemd: name=puma enabled=yes

--- a/ansible/roles/app/tasks/ruby.yml
+++ b/ansible/roles/app/tasks/ruby.yml
@@ -1,0 +1,8 @@
+---
+- name: Install ruby and rubygems and required packages
+  apt: "name={{ item }} state=present"
+  with_items:
+    - ruby-full
+    - ruby-bundler
+    - build-essential
+  tags: ruby

--- a/ansible/roles/app/templates/puma.service.j2
+++ b/ansible/roles/app/templates/puma.service.j2
@@ -4,9 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
-EnvironmentFile=/home/appuser/db_config
-User=appuser
-WorkingDirectory=/home/appuser/reddit
+EnvironmentFile=/home/{{ deploy_user }}/db_config
+User={{ deploy_user }}
+WorkingDirectory=/home/{{ deploy_user }}/reddit
 ExecStart=/bin/bash -lc 'puma'
 Restart=always
 

--- a/ansible/roles/db/.yamllint
+++ b/ansible/roles/db/.yamllint
@@ -1,0 +1,11 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  truthy: disable

--- a/ansible/roles/db/molecule/default/INSTALL.rst
+++ b/ansible/roles/db/molecule/default/INSTALL.rst
@@ -1,0 +1,23 @@
+*******
+Vagrant driver installation guide
+*******
+
+Requirements
+============
+
+* Vagrant
+* Virtualbox, Parallels, VMware Fusion, VMware Workstation or VMware Desktop
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[vagrant]'

--- a/ansible/roles/db/molecule/default/molecule.yml
+++ b/ansible/roles/db/molecule/default/molecule.yml
@@ -1,0 +1,20 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+lint:
+  name: yamllint
+platforms:
+  - name: instance
+    box: ubuntu/xenial64
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/ansible/roles/db/molecule/default/playbook.yml
+++ b/ansible/roles/db/molecule/default/playbook.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  become: true
+  hosts: all
+  vars:
+    mongo_bind_ip: 0.0.0.0
+  roles:
+    - role: db

--- a/ansible/roles/db/molecule/default/prepare.yml
+++ b/ansible/roles/db/molecule/default/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      become: true
+      changed_when: false

--- a/ansible/roles/db/molecule/default/tests/test_default.py
+++ b/ansible/roles/db/molecule/default/tests/test_default.py
@@ -1,0 +1,21 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+# check if MongoDB is enabled and running
+def test_mongo_running_and_enabled(host):
+    mongo = host.service("mongod")
+    assert mongo.is_running
+    assert mongo.is_enabled
+
+# check if configuration file contains the required line
+def test_config_file(host):
+    config_file = host.file('/etc/mongod.conf')
+    assert config_file.contains('bindIp: 0.0.0.0')
+    assert config_file.is_file
+
+def test_mongo_listening(host):
+    assert host.socket("tcp://0.0.0.0:27017").is_listening

--- a/ansible/roles/db/tasks/config_mongo.yml
+++ b/ansible/roles/db/tasks/config_mongo.yml
@@ -1,0 +1,7 @@
+---
+- name: Change mongo config file
+  template:
+    src: templates/mongod.conf.j2
+    dest: /etc/mongod.conf
+    mode: 0644
+  notify: restart mongod

--- a/ansible/roles/db/tasks/install_mongo.yml
+++ b/ansible/roles/db/tasks/install_mongo.yml
@@ -1,0 +1,24 @@
+- name: Add APT key
+  apt_key:
+    id: "EA312927"
+    keyserver: keyserver.ubuntu.com
+  tags: install
+
+- name: Add APT repository
+  apt_repository:
+    repo: deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse
+    state: present
+  tags: install
+
+- name: Install mongodb package
+  apt:
+    name: mongodb-org
+    state: present
+  tags: install
+
+- name: Configure service supervisor
+  systemd:
+    name: mongod
+    enabled: yes
+    state: started
+  tags: install

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -1,12 +1,9 @@
 ---
 # tasks file for db
+
 - name: Show info about the env this host belongs to
   debug:
-    msg: "This host is in {{ env }} environment"
+    msg: "This host is in {{ env }} environment!!!"
 
-- name: Change mongo config file
-  template:
-    src: mongod.conf.j2
-    dest: /etc/mongod.conf
-    mode: 0644
-  notify: restart mongod
+- include: install_mongo.yml
+- include: config_mongo.yml

--- a/packer/app.json
+++ b/packer/app.json
@@ -29,8 +29,10 @@
     ],
     "provisioners": [
         {
-            "type": "ansible",
-            "playbook_file": "ansible/playbooks/packer_app.yml"
+        "type": "ansible",
+        "playbook_file": "ansible/playbooks/packer_app.yml",
+        "extra_arguments": ["--tags","ruby"],
+        "ansible_env_vars": ["ANSIBLE_ROLES_PATH=ansible/roles"]
         }
     ]
 }

--- a/packer/db.json
+++ b/packer/db.json
@@ -27,8 +27,10 @@
     ],
     "provisioners": [
         {
-            "type": "ansible",
-            "playbook_file": "ansible/playbooks/packer_db.yml"
+        "type": "ansible",
+        "playbook_file": "ansible/playbooks/packer_db.yml",
+        "extra_arguments": ["--tags","install"],
+        "ansible_env_vars": ["ANSIBLE_ROLES_PATH=ansible/roles"]
         }
     ]
 }


### PR DESCRIPTION
# Выполнено ДЗ №13

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- Установлен VirtualBox и Vagrant
- В .gitignore добавлены исключения для Vagrant и molecule
- В ./ansible добавлен vagrantfile с описанием vm appserver и dbserver
- Подняты машины appserver и dbserver

```bash
vagrant status

Current machine states:

dbserver                  running (virtualbox)
appserver                 running (virtualbox)
```

- Машины доступны по ssh и отвечают на ping

### Доработка ролей

- В Vagrantfile добавлен ansible-провижинер для vm dbserver
- Добавлен новый плейбук ./ansible/playbooks/base.yml, он импортирован в ./ansible/playbooks/site.yml
- В base.yml описана проверка наличия и, в случае отсуствия, установка python для обеспечения работы ansible
- В роль db добавлен файл тасков ./ansible/roles/db/tasks/install_mongo.yml описывающий установку MongoDB
- Шаг настройки mongoDB вынесен из main.yml в отдельный файл ./ansible/roles/db/tasks/config_mongo.yml
- В ./ansible/roles/db/tasks/main.yml добавлены запуски тасков в нужном нам порядке
- Выполнен провижининг dbserver посредством `vagrant provision dbserver`
- Проверена доступность порта 27017 c appserver
- Добавлен файл ./ansible/roles/app/tasks/ruby.yml описывающий установку ruby, rubygems и зависимостей
- Так же добавлен файл ./ansible/roles/app/tasks/puma.yml описывающий настройку puma-server
- В ./ansible/roles/app/tasks/main.yml добавлены include в нужном порядке
- В Vagrantfile добавлен провижининг appserver сердствами ansible
- Выполнен провижининг appserver `vagrant provision appserver`
- В ./ansible/roles/app/defaults/main.yml добавлена переменная deploy_user
- В puma.yml копирование unit-файла через copy заменено на использование template
- Unit-файл puma.service преобразован в jinja-шаблон и параметризован
- Параметризован плейбук ./ansible/roles/app/tasks/puma.yml
- Параметризован плейбук ./ansible/playbooks/deploy.yml
- В Vagrantfile добавлено определение значения перемменной deploy_user
- Проверил настройку appserver через `vagrant provision appserver`
- Исправил две проблемы: поменял пользователя deploy_user на vagrant, убрал запуск handler restart puma после добавления unit-файла
- Убедился в том, что сервис поднялся и доступен на 10.10.10.20:9292
- Проверил конфигурацию через vagrant destroy -f / vagrant up

### HW13: Задание со *

- Для того чтобы nginx проксировал запросы к приложению в vagrantfile добавлены настройки аналогично тому, как это было настроено в ./ansible/group_vars/app

<details>
  <summary>nginx options</summary>

```ruby
ansible.extra_vars = {"deploy_user" => "vagrant",
      "nginx_sites" => {
        "default" => [
          "listen 80 default_server",
          "server_name reddit",
          "location / { proxy_pass http://127.0.0.1:9292; }"
        ]
      }
```

</details>

### Тестирование роли

- Настроил virtualenv
- Установил ansible, molecule, testinfra, python-vagrant
- Создал заготовку тестов роли db: "molecule init scenario --scenario-name default -r db -d vagrant"
- Добавил тесты в ./ansible/roles/db/molecule/default/tests/test_default.py
- Добавил описание тестовой машины в ./ansible/roles/db/molecule/default/molecule.yml
- Создал VM через "molecule create"
- Убедился в возможности подключитьсяк инстансу через molecule login -h instance
- Добавил запуск от root (become: true) и переменную mongo_bind_ip в ./ansible/roles/db/molecule/default/playbook.yml
- Применил конфигурацию инстанса через molecule converge
- Запустил тесты через molecule verify и убедился что они работают

### HW13: Самостоятельное задание

- Добавил в ./ansible/roles/db/molecule/default/tests/test_default.py

<details>
  <summary>molecule mongo port</summary>

```python
def test_mongo_listening(host):
    assert host.socket("tcp://0.0.0.0:27017").is_listening
```

</details>

- Перевел плейбуки packer_app.yml и packer_db.yml на использование ролей app и db соответственно, указал в шаблонах пакера откуда брать роли и с каким тэгом их запускать

<details>
  <summary>packer app provisioner</summary>

```json
"provisioners": [
    {
    "type": "ansible",
    "playbook_file": "ansible/playbooks/packer_app.yml",
    "extra_arguments": ["--tags","ruby"],
    "ansible_env_vars": ["ANSIBLE_ROLES_PATH=ansible/roles"]
    }
]
```

</details>

<details>
  <summary>packer db provisioner</summary>

```json
"provisioners": [
    {
    "type": "ansible",
    "playbook_file": "ansible/playbooks/packer_db.yml",
    "extra_arguments": ["--tags","install"],
    "ansible_env_vars": ["ANSIBLE_ROLES_PATH=ansible/roles"]
    }
]
```

</details>

- Проверил сборку шаблонов packer'ом


## Как запустить проект:
- Выполнить `vagrant up` в ./ansible
- В ./ansible выполнить `pip install -r requirements.txt`
- В ./ansible/roles/db выполнить `molecule create && molecule verify`

## Как проверить работоспособность:
- Для Vagrant: перейти по ссылке http://10.10.10.20:80
- Для molecule: тесты должны пройти без ошибок

## PR checklist
 - [x] Выставил label с номером домашнего задания
 - [x] Выставил label с темой домашнего задания